### PR TITLE
Working on V8 build and linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+
+export PATH := ${PATH}:$(shell pwd)/depot_tools
+
+TARGET := native
+
+lib: v8 include libv8
+	GYPFLAGS="-Dv8_use_external_startup_data=0 -Dv8_enable_i18n_support=0 -Dv8_enable_gdbjit=0" make -C v8 ${TARGET} i18nsupport=off
+	strip -S v8/out/${TARGET}/libv8_*.a
+	cp v8/out/${TARGET}/*.a libv8/
+	cp v8/include/*.h include/
+	cp -r v8/include/libplatform include/
+
+v8:
+	fetch --nohooks v8
+	cd v8 && gclient sync
+
+libv8:
+	mkdir libv8
+
+include:
+	mkdir include
+	
+depot_tools :
+	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git

--- a/v8.go
+++ b/v8.go
@@ -11,7 +11,7 @@ package v8
 // #include <stdlib.h>
 // #include <string.h>
 // #include "v8_c_bridge.h"
-// #cgo CXXFLAGS: -I${SRCDIR} -I${SRCDIR}/include -std=c++11
+// #cgo CXXFLAGS: -I${SRCDIR} -I${SRCDIR}/include -std=c++11 -fno-rtti
 // #cgo LDFLAGS: -L${SRCDIR}/libv8 -lv8_base -lv8_libbase -lv8_snapshot -lv8_libsampler -lv8_libplatform -ldl -pthread
 import "C"
 


### PR DESCRIPTION
This PR adds a Makefile to download and build V8. It also adds a `-fno-rtti` compiler flag to the cgo build to eliminate some linking problems.