### PR TITLE
Update README.md for v8 download and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ ninja -C out.gn/golib
 ## OSX
 
 ```
-export V8_OSX_SDK_VERSION=`xcrun --sdk macosx --show-sdk-path|awk -F "/" '{print $NF}'|grep -o '\d\+\.\d\+'`
-gn gen out.gn/golib --args="mac_deployment_target=\"$V8_OSX_SDK_VERSION\" is_official_build=true strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library=true"
+gn gen out.gn/golib --args="is_official_build=true strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library=true"
 ninja -C out.gn/golib
 # go get some coffee
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ gclient sync
 ## Linux
 ```
 ./build/install-build-deps.sh #only needed once
-gn gen out.gn/golib --args="is_official_build=true strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library = true"
+gn gen out.gn/golib --args="is_official_build=true strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library=true"
 ninja -C out.gn/golib
 # go get some coffee
 ```
@@ -51,7 +51,7 @@ ninja -C out.gn/golib
 
 ```
 export V8_OSX_SDK_VERSION=`xcrun --sdk macosx --show-sdk-path|awk -F "/" '{print $NF}'|grep -o '\d\+\.\d\+'`
-gn gen out.gn/golib --args="mac_deployment_target=\"$V8_OSX_SDK_VERSION\" is_official_build=true strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library = true"
+gn gen out.gn/golib --args="mac_deployment_target=\"$V8_OSX_SDK_VERSION\" is_official_build=true strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library=true"
 ninja -C out.gn/golib
 # go get some coffee
 ```

--- a/README.md
+++ b/README.md
@@ -42,26 +42,16 @@ gclient sync
 ## Linux
 ```
 ./build/install-build-deps.sh #only needed once
-gn gen out.gn/golib --args="is_official_build=true strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library=true"
+gn gen out.gn/golib --args="strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library=true symbol_level=0 v8_experimental_extra_library_files=[] v8_extra_library_files=[]"
 ninja -C out.gn/golib
 # go get some coffee
 ```
 
 ## OSX
-
 ```
-gn gen out.gn/golib --args="is_official_build=true strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library=true"
+gn gen out.gn/golib --args="is_official_build=true strip_debug_info=true v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_static_library=true symbol_level=0 v8_experimental_extra_library_files=[] v8_extra_library_files=[]"
 ninja -C out.gn/golib
 # go get some coffee
-```
-
-On MacOS, the resulting libraries contain debugging information by default (even
-though we've built the release version). As a result, the binaries are 30x
-larger, then they should be. Strip that to reduce the size of the archives (and
-build times!) very significantly:
-
-```
-strip -S $V8_BUILD/v8/out.gn/golib/obj/*.a
 ```
 
 ## Symlinking


### PR DESCRIPTION
The docs were way out of date as discussed in #8. Most notably, make is no longer the recommended method for building, `v8_static_library` needs to be specified directly, and `sw_vers -productVersion` on OSX is actually too specific and will generate annoying warnings like the following:

`ld: warning: object file (foo.a(bar.c.o)) was built for newer OSX version (10.13.3) than being linked (10.13)`

I also modified the build instructions to just build v8 directly from the library path, and I removed the bit about fat binaries under linux as I wasn't sure if it applied any longer. Please feel free to verify.