### PR TITLE
HeapStatistics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
   # - V8_VERSION=6.2.414.42.1
   # - V8_VERSION=6.0.286.54.3
 
+go_import_path: github.com/augustoroman/v8
+
 # Need to download & compile v8 libraries before running the tests.
 install: ./travis-install-linux.sh
 

--- a/v8.go
+++ b/v8.go
@@ -547,9 +547,10 @@ type HeapStatistics struct {
 	HeapSizeLimit           uint64
 	MallocedMemory          uint64
 	PeakMallocedMemory      uint64
-	DoesZapGarbage          uint64
+	DoesZapGarbage          bool
 }
 
+// GetHeapStatistics gets statistics about the heap memory usage.
 func (i *Isolate) GetHeapStatistics() HeapStatistics {
 	hs := C.v8_Isolate_GetHeapStatistics(i.ptr)
 	return HeapStatistics{
@@ -561,10 +562,13 @@ func (i *Isolate) GetHeapStatistics() HeapStatistics {
 		HeapSizeLimit:           uint64(hs.heap_size_limit),
 		MallocedMemory:          uint64(hs.malloced_memory),
 		PeakMallocedMemory:      uint64(hs.peak_malloced_memory),
-		DoesZapGarbage:          uint64(hs.does_zap_garbage),
+		DoesZapGarbage:          hs.does_zap_garbage == 1,
 	}
 }
 
-func (i *Isolate) LowMemoryNotification() {
+// SendLowMemoryNotification sends an optional notification that the
+// system is running low on memory. V8 uses these notifications to
+// attempt to free memory.
+func (i *Isolate) SendLowMemoryNotification() {
 	C.v8_Isolate_LowMemoryNotification(i.ptr)
 }

--- a/v8.go
+++ b/v8.go
@@ -538,6 +538,8 @@ func go_callback_handler(
 	return C.ValueErrorPair{Value: res.ptr}
 }
 
+// HeapStatistics represent v8::HeapStatistics which are statistics
+// about the heap memory usage.
 type HeapStatistics struct {
 	TotalHeapSize           uint64
 	TotalHeapSizeExecutable uint64

--- a/v8.go
+++ b/v8.go
@@ -537,3 +537,34 @@ func go_callback_handler(
 
 	return C.ValueErrorPair{Value: res.ptr}
 }
+
+type HeapStatistics struct {
+	TotalHeapSize           uint64
+	TotalHeapSizeExecutable uint64
+	TotalPhysicalSize       uint64
+	TotalAvailableSize      uint64
+	UsedHeapSize            uint64
+	HeapSizeLimit           uint64
+	MallocedMemory          uint64
+	PeakMallocedMemory      uint64
+	DoesZapGarbage          uint64
+}
+
+func (i *Isolate) GetHeapStatistics() HeapStatistics {
+	hs := C.v8_Isolate_GetHeapStatistics(i.ptr)
+	return HeapStatistics{
+		TotalHeapSize:           uint64(hs.total_heap_size),
+		TotalHeapSizeExecutable: uint64(hs.total_heap_size_executable),
+		TotalPhysicalSize:       uint64(hs.total_physical_size),
+		TotalAvailableSize:      uint64(hs.total_available_size),
+		UsedHeapSize:            uint64(hs.used_heap_size),
+		HeapSizeLimit:           uint64(hs.heap_size_limit),
+		MallocedMemory:          uint64(hs.malloced_memory),
+		PeakMallocedMemory:      uint64(hs.peak_malloced_memory),
+		DoesZapGarbage:          uint64(hs.does_zap_garbage),
+	}
+}
+
+func (i *Isolate) LowMemoryNotification() {
+	C.v8_Isolate_LowMemoryNotification(i.ptr)
+}

--- a/v8_c_bridge.cc
+++ b/v8_c_bridge.cc
@@ -21,7 +21,6 @@
   v8::Local<v8::Context> ctx(static_cast<Context*>(ctxptr)->ptr.Get(isolate));                \
   v8::Context::Scope context_scope(ctx);                 /* Scope to this context.         */
 
-
 extern "C" ValueErrorPair go_callback_handler(
     String id, CallerInfo info, int argc, PersistentValuePtr* argv);
 
@@ -530,6 +529,34 @@ unsigned char* v8_Value_Bytes(ContextPtr ctxptr, PersistentValuePtr valueptr, in
     *length = bufPtr->GetContents().ByteLength();
   }
   return static_cast<unsigned char*>(bufPtr->GetContents().Data());
+}
+
+HeapStatistics v8_Isolate_GetHeapStatistics(IsolatePtr isolate_ptr) {
+  if (isolate_ptr == nullptr) {
+    return HeapStatistics{0};
+  }
+  ISOLATE_SCOPE(static_cast<v8::Isolate*>(isolate_ptr));
+  v8::HeapStatistics hs;
+  isolate->GetHeapStatistics(&hs);
+  return HeapStatistics{
+    hs.total_heap_size(),
+    hs.total_heap_size_executable(),
+    hs.total_physical_size(),
+    hs.total_available_size(),
+    hs.used_heap_size(),
+    hs.heap_size_limit(),
+    hs.malloced_memory(),
+    hs.peak_malloced_memory(),
+    hs.does_zap_garbage()
+  };
+}
+
+void v8_Isolate_LowMemoryNotification(IsolatePtr isolate_ptr) {
+  if (isolate_ptr == nullptr) {
+    return;
+  }
+  ISOLATE_SCOPE(static_cast<v8::Isolate*>(isolate_ptr));
+  isolate->LowMemoryNotification();
 }
 
 } // extern "C"

--- a/v8_c_bridge.h
+++ b/v8_c_bridge.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 #ifndef V8_C_BRIDGE_H
 #define V8_C_BRIDGE_H
 
@@ -16,6 +18,18 @@ typedef struct {
 
 typedef String Error;
 typedef String StartupData;
+
+typedef struct {
+    size_t total_heap_size;
+    size_t total_heap_size_executable;
+    size_t total_physical_size;
+    size_t total_available_size;
+    size_t used_heap_size;
+    size_t heap_size_limit;
+    size_t malloced_memory;
+    size_t peak_malloced_memory;
+    size_t does_zap_garbage;
+} HeapStatistics;
 
 typedef struct {
     PersistentValuePtr Value;
@@ -43,6 +57,9 @@ extern IsolatePtr v8_Isolate_New(StartupData data);
 extern ContextPtr v8_Isolate_NewContext(IsolatePtr isolate);
 extern void       v8_Isolate_Terminate(IsolatePtr isolate);
 extern void       v8_Isolate_Release(IsolatePtr isolate);
+
+extern HeapStatistics       v8_Isolate_GetHeapStatistics(IsolatePtr isolate);
+extern void       v8_Isolate_LowMemoryNotification(IsolatePtr isolate);
 
 extern ValueErrorPair     v8_Context_Run(ContextPtr ctx,
                                          const char* code, const char* filename);
@@ -78,7 +95,6 @@ extern ValueErrorPair  v8_Value_New(ContextPtr ctx,
 extern void   v8_Value_Release(ContextPtr ctx, PersistentValuePtr value);
 extern String v8_Value_String(ContextPtr ctx, PersistentValuePtr value);
 extern unsigned char* v8_Value_Bytes(ContextPtr ctx, PersistentValuePtr value, int * length);
-
 
 #ifdef __cplusplus
 }

--- a/v8_test.go
+++ b/v8_test.go
@@ -1148,15 +1148,34 @@ func TestContextFinalizerWithValues(t *testing.T) {
 
 func TestIsolateGetHeapStatistics(t *testing.T) {
 	iso := NewIsolate()
-	h := iso.GetHeapStatistics()
-	if h.TotalHeapSize <= 0 {
-		t.Fatalf("expected heap to be more than zero, got: %d\n", h.TotalHeapSize)
+	initHeap := iso.GetHeapStatistics()
+	if initHeap.TotalHeapSize <= 0 {
+		t.Fatalf("expected heap to be more than zero, got: %d\n", initHeap.TotalHeapSize)
 	}
-}
 
-func TestIsolateLowMemoryNotification(t *testing.T) {
-	iso := NewIsolate()
-	iso.LowMemoryNotification() // checks it exists and doesn't bomb.
+	ctx := iso.NewContext()
+	for i := 0; i < 10000; i++ {
+		ctx.Create(map[string]interface{}{
+			"hello": map[string]interface{}{
+				"world": []string{"foo", "bar"},
+			},
+		})
+	}
+
+	midHeap := iso.GetHeapStatistics()
+	if midHeap.TotalHeapSize <= initHeap.TotalHeapSize {
+		t.Fatalf("expected heap to grow after creating context, got: %d\n", midHeap.TotalHeapSize)
+	}
+
+	beforeNotifyHeap := iso.GetHeapStatistics()
+
+	iso.SendLowMemoryNotification()
+
+	finalHeap := iso.GetHeapStatistics()
+	if finalHeap.TotalHeapSize >= beforeNotifyHeap.TotalHeapSize {
+		t.Fatalf("expected heap to reduce after terminating context, got: %d\n", finalHeap.TotalHeapSize)
+	}
+
 }
 
 func runGcUntilReceivedOrTimedOut(signal <-chan bool, timeout time.Duration) bool {

--- a/v8_test.go
+++ b/v8_test.go
@@ -1146,6 +1146,19 @@ func TestContextFinalizerWithValues(t *testing.T) {
 	}
 }
 
+func TestIsolateGetHeapStatistics(t *testing.T) {
+	iso := NewIsolate()
+	h := iso.GetHeapStatistics()
+	if h.TotalHeapSize <= 0 {
+		t.Fatalf("expected heap to be more than zero, got: %d\n", h.TotalHeapSize)
+	}
+}
+
+func TestIsolateLowMemoryNotification(t *testing.T) {
+	iso := NewIsolate()
+	iso.LowMemoryNotification() // checks it exists and doesn't bomb.
+}
+
 func runGcUntilReceivedOrTimedOut(signal <-chan bool, timeout time.Duration) bool {
 	expired := time.After(timeout)
 	for {


### PR DESCRIPTION
Adds:
- A struct and function to get at `v8::HeapStatistics` for an Isolate.
- Adds wrapper for `LowMemoryNotification()` on an Isolate.

Fixes travis for forks, forcing the import path.

I've added 2 tests, but they're not exhaustive. Not entirely sure how I should be testing either of those. Right now it mostly tests that the functions exists. HeapStatistics are too unpredictable to test the values returned.