### PR TITLE
Don't release already-created intermediate *Value

### DIFF
--- a/v8_test.go
+++ b/v8_test.go
@@ -930,13 +930,16 @@ func TestCreateComplex(t *testing.T) {
 	zzz4 := &zzz3
 	zzz5 := &zzz4 // zzz5 is a *****Struct.  Make sure pointers work!
 
+	fn2 := ctx.Bind("fn2", fn)
+
 	val, err := ctx.Create([]Struct{
 		{"asdf", false, nil},
 		{"foo", true, map[string]interface{}{
-			"num":  123.123,
-			"fn":   fn,
-			"fn2":  ctx.Bind("fn2", fn),
-			"list": []float64{1, 2, 3},
+			"num":    123.123,
+			"fn":     fn,
+			"fn2":    fn2,
+			"list":   []float64{1, 2, 3},
+			"valArr": []*Value{fn2},
 		}},
 		{"*****Struct", false, zzz5},
 		{"bufbuf", false, struct {
@@ -945,9 +948,16 @@ func TestCreateComplex(t *testing.T) {
 		{"emptybuf", false, struct {
 			Data []byte `v8:"arraybuffer"`
 		}{[]byte{}}},
+		{"structwvalue", false, struct {
+			Val *Value
+		}{fn2}},
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if fn2.ptr == nil {
+		t.Error("*Value should not release already-created *Value")
 	}
 
 	ctx.Global().Set("mega", val)


### PR DESCRIPTION
I started getting issues where values I had pre-created and saved for later use were getting released when using `ctx.Create`. When my code called ctx.Create a second time with the previously-saved `*Value`s, it would segfault due to a null pointer.

This PR checks if the map value, slice value and struct value types are of `*Value` and will not release them automatically if that's the case.

I'm sure there are prettier ways of doing this, but it seems the simplest without changing function signatures.