### PR TITLE
Update README.md to checkout working branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 export PATH=$PATH:$V8_BUILD/depot_tools
 fetch v8 #pull down v8 (this will take some time)
 cd v8
+git checkout 6.7.77
 gclient sync
 ```
 


### PR DESCRIPTION
This change to the instructions was required before "go test" would work when building your own v8 (on MacOS).