### PR TITLE
Added KindsOf method to Value type

### DIFF
--- a/kind.go
+++ b/kind.go
@@ -121,6 +121,17 @@ func (k Kind) String() string {
 
 func (k Kind) mask() kindMask { return kindMask(1 << k) }
 
+// KindList List of Kinds pretty self explanitory
+type KindList []Kind
+
+func (kinds KindList) String() string {
+	var res []string
+	for _, kind := range kinds {
+		res = append(res, kind.String())
+	}
+	return strings.Join(res, ",")
+}
+
 type kindMask uint64
 
 // if kNumKinds > 64, then this will fail at compile time.
@@ -131,14 +142,20 @@ func (mask kindMask) Is(k Kind) bool {
 }
 
 func (mask kindMask) String() string {
-	var res []string
+	kinds := mask.Kinds()
+	return kinds.String()
+}
+
+func (mask kindMask) Kinds() KindList {
+	var kinds KindList
 	for k := Kind(0); k < kNumKinds; k++ {
 		if mask.Is(k) {
-			res = append(res, k.String())
+			kinds = append(kinds, k)
 		}
 	}
-	return strings.Join(res, ",")
+	return kinds
 }
+
 
 func mask(kinds ...Kind) kindMask {
 	var res kindMask

--- a/v8.go
+++ b/v8.go
@@ -449,6 +449,12 @@ func (v *Value) IsKind(k Kind) bool {
 	return v.kindMask.Is(k)
 }
 
+// KindsOf will get a list of Kinds for the underlying value.
+// The kind of a value is set when the value is created and will not change.
+func (v *Value) KindsOf() KindList {
+	return v.kindMask.Kinds()
+}
+
 // New creates a new instance of an object using this value as its constructor.
 // If this value is not a function, this will fail.
 func (v *Value) New(args ...*Value) (*Value, error) {


### PR DESCRIPTION
Pretty simple stuff just added a `KindsOf` method for the `Value` type, and a `KindList` type with a method `String`.

Should allow for a little better error reporting from bound functions.

I.E.
```
func someBoundMethod(in v8.CallbackArgs) (*v8.Value, error) {
    if !in.Arg(0).IsKind(v8.KindString) {
	return nil, errors.New("Expected String type for arg 0 but got: " + in.Arg(0).KindsOf().String() + ".")
    }
} 
```

I would imagine there are other uses this is just the one that motivated me to make this pr.