### PR TITLE
fix: Snapshot may be recycled early, causing panic

### DIFF
--- a/v8.go
+++ b/v8.go
@@ -146,7 +146,10 @@ func CreateSnapshot(js string) *Snapshot {
 // Isolate represents a single-threaded V8 engine instance.  It can run multiple
 // independent Contexts and V8 values can be freely shared between the Contexts,
 // however only one context will ever execute at a time.
-type Isolate struct{ ptr C.IsolatePtr }
+type Isolate struct {
+	ptr C.IsolatePtr
+	s   *Snapshot // make sure not to be advanced GC
+}
 
 // NewIsolate creates a new V8 Isolate.
 func NewIsolate() *Isolate {
@@ -160,7 +163,7 @@ func NewIsolate() *Isolate {
 // to initialize all Contexts created from this Isolate.
 func NewIsolateWithSnapshot(s *Snapshot) *Isolate {
 	v8_init_once.Do(func() { C.v8_init() })
-	iso := &Isolate{C.v8_Isolate_New(s.data)}
+	iso := &Isolate{ptr: C.v8_Isolate_New(s.data), s: s}
 	runtime.SetFinalizer(iso, (*Isolate).release)
 	return iso
 }

--- a/v8.go
+++ b/v8.go
@@ -154,7 +154,7 @@ type Isolate struct {
 // NewIsolate creates a new V8 Isolate.
 func NewIsolate() *Isolate {
 	v8_init_once.Do(func() { C.v8_init() })
-	iso := &Isolate{C.v8_Isolate_New(C.StartupData{ptr: nil, len: 0})}
+	iso := &Isolate{ptr: C.v8_Isolate_New(C.StartupData{ptr: nil, len: 0})}
 	runtime.SetFinalizer(iso, (*Isolate).release)
 	return iso
 }


### PR DESCRIPTION
the panic log:

```
#
# Fatal error in ../src/snapshot/snapshot-common.cc, line 261
# Check failed: index < num_contexts.
#

==== C stack trace ===============================

    /data00/home/henrylee2cn/go/src/git.byted.org/v8worker/plugin/lib.1.0.0/libv8worker-go1.11-linux-amd64.so(v8::base::debug::StackTrace::StackTrace()+0xe) [0x7f7122a09d1e]
    /data00/home/henrylee2cn/go/src/git.byted.org/v8worker/plugin/lib.1.0.0/libv8worker-go1.11-linux-amd64.so(+0xda9580) [0x7f7122a02580]
    /data00/home/henrylee2cn/go/src/git.byted.org/v8worker/plugin/lib.1.0.0/libv8worker-go1.11-linux-amd64.so(V8_Fatal(char const*, int, char const*, ...)+0xe2) [0x7f71229fd342]
    /data00/home/henrylee2cn/go/src/git.byted.org/v8worker/plugin/lib.1.0.0/libv8worker-go1.11-linux-amd64.so(v8::internal::Snapshot::ExtractContextData(v8::StartupData const*, unsigned int)+0x96) [0x7f71226537a6]
    /data00/home/henrylee2cn/go/src/git.byted.org/v8worker/plugin/lib.1.0.0/libv8worker-go1.11-linux-amd64.so(v8::internal::Snapshot::NewContextFromSnapshot(v8::internal::Isolate*, v8::internal::Handle<v8::internal::JSGlobalProxy>, unsigned long, v8::DeserializeInternalFieldsCallback)+0x6d) [0x7f712265383d]
    /data00/home/henrylee2cn/go/src/git.byted.org/v8worker/plugin/lib.1.0.0/libv8worker-go1.11-linux-amd64.so(v8::internal::Genesis::Genesis(v8::internal::Isolate*, v8::internal::MaybeHandle<v8::internal::JSGlobalProxy>, v8::Local<v8::ObjectTemplate>, unsigned long, v8::DeserializeInternalFieldsCallback, v8::internal::GlobalContextType)+0x1cd) [0x7f71223479cd]
    /data00/home/henrylee2cn/go/src/git.byted.org/v8worker/plugin/lib.1.0.0/libv8worker-go1.11-linux-amd64.so(v8::internal::Bootstrapper::CreateEnvironment(v8::internal::MaybeHandle<v8::internal::JSGlobalProxy>, v8::Local<v8::ObjectTemplate>, v8::ExtensionConfiguration*, unsigned long, v8::DeserializeInternalFieldsCallback, v8::internal::GlobalContextType)+0x4d) [0x7f712234854d]
    /data00/home/henrylee2cn/go/src/git.byted.org/v8worker/plugin/lib.1.0.0/libv8worker-go1.11-linux-amd64.so(v8::NewContext(v8::Isolate*, v8::ExtensionConfiguration*, v8::MaybeLocal<v8::ObjectTemplate>, v8::MaybeLocal<v8::Value>, unsigned long, v8::DeserializeInternalFieldsCallback)+0x41f) [0x7f712230132f]
    /data00/home/henrylee2cn/go/src/git.byted.org/v8worker/plugin/lib.1.0.0/libv8worker-go1.11-linux-amd64.so(v8::Context::New(v8::Isolate*, v8::ExtensionConfiguration*, v8::MaybeLocal<v8::ObjectTemplate>, v8::MaybeLocal<v8::Value>, v8::DeserializeInternalFieldsCallback)+0x15) [0x7f71223019e5]
```